### PR TITLE
Fix a TypeError when using webpack 2.2.0+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,9 @@ export default function(content) {
         translations = extractTranslations(this, content, options),
         module = interpolateModule(this, translations, options);
 
-    this.value = translations;
+    if (typeof this.setTranslationsForTesting == 'function') {
+        this.setTranslationsForTesting(translations);
+    }
 
     return generateContent(module, locale, translations);
 }

--- a/test/helpers/makeRequest.js
+++ b/test/helpers/makeRequest.js
@@ -18,6 +18,10 @@ export default (resourcePath, callback, options = {}, query = null) => {
             delete options[x];
         });
 
+        context.setTranslationsForTesting = function (translations) {
+            this.value = translations;
+        }
+
         if (err) {
             json = options.content;
         }


### PR DESCRIPTION
The [`loaderContext` provided by webpack 2.2.0 and newer is not extensible][loadercontext], so setting
`this.value` throws a TypeError when I use angular-translate-loader.

I think the loader is setting `this.value` just for testing, so this PR makes the loader look for a special function added by the tests and uses it.

The name `setTranslationsForTesting ` is verbose, but I chose that name because I thought it would make it clear this is just a hook for testing. If preferred, I can revert to setting `this.value` and just test `Object.isExtensible(this)` instead.

[loadercontext]: https://github.com/webpack/loader-runner/blob/baa14f5e7ed6c034ca241a2c4a545195e773c9d3/lib/LoaderRunner.js#L353-L356